### PR TITLE
Fix cross-platform build and update tests

### DIFF
--- a/crossdaemonize-tests/src/lib.rs
+++ b/crossdaemonize-tests/src/lib.rs
@@ -42,9 +42,9 @@ pub const ADDITIONAL_FILE_DATA: &str = "additional file data";
 
 // Caminho para o executável tester.exe (localizado em examples/ dentro do seu próprio projeto)
 const TESTER_PATH: &str = if cfg!(windows) {
-    "./target/debug/examples/tester.exe"
+    "../target/debug/examples/tester.exe"
 } else {
-    "./target/debug/examples/tester"
+    "../target/debug/examples/tester"
 };
 
 const MAX_WAIT_DURATION: std::time::Duration = std::time::Duration::from_secs(5);

--- a/crossdaemonize-tests/tests/tests.rs
+++ b/crossdaemonize-tests/tests/tests.rs
@@ -25,7 +25,14 @@ fn chdir() {
     assert!(_result_chdir.is_ok(), "chdir test failed: {:?}", _result_chdir.unwrap_err());
 
     #[cfg(unix)]
-    assert_eq!(_result_chdir.unwrap().cwd.as_str(), "/usr"); // Unix geralmente espera /usr ou /, não "test_chdir_target"
+    {
+        let expected_cwd = temp_dir_for_chdir.path().canonicalize()
+            .expect("Failed to canonicalize path for chdir test")
+            .to_string_lossy()
+            .to_string();
+        let actual_cwd = _result_chdir.unwrap().cwd;
+        assert_eq!(actual_cwd, expected_cwd, "CWD should match the temporary directory on Unix");
+    }
     #[cfg(windows)]
     {
         // Canonicalize para resolver ., .. e garantir o formato completo.

--- a/crossdaemonize/examples/complex.rs
+++ b/crossdaemonize/examples/complex.rs
@@ -1,4 +1,4 @@
-extern crate daemonize;
+extern crate crossdaemonize as daemonize;
 
 use std::fs::File;
 


### PR DESCRIPTION
## Summary
- clean up Windows gating logic in the library
- use MutexHandle alias for non-Windows builds
- import missing traits for Unix
- adjust Display implementation for Windows-only variant
- fix example path and update tests

## Testing
- `cargo build -p crossdaemonize-tests --examples`
- `cargo test -p crossdaemonize-tests -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_683f537c5a1c83268e4bd25c1b584a59